### PR TITLE
WL-3675 Fixed the Email exception.

### DIFF
--- a/impl/logic/src/java/org/sakaiproject/emailtemplateservice/service/impl/EmailTemplateServiceImpl.java
+++ b/impl/logic/src/java/org/sakaiproject/emailtemplateservice/service/impl/EmailTemplateServiceImpl.java
@@ -431,8 +431,11 @@ public void sendRenderedMessages(String key, List<String> userReferences,
 				String body = message.toString();
 				log.debug("message body " + body);
 				if(newUserId != null){
+					//EmailService 'send' method uses additionalHeaders differently from 'sendToUsers' so can't use 'headers' in this method.
+					List<String> additionalHeaders = new ArrayList<String>();
+					additionalHeaders.add("Content-Type: text/html; charset=UTF-8");
 					//sending email to new email address for user who has updated the email
-					emailService.send(fromEmail, toEmail, rt.getRenderedSubject(), body, toEmail, fromEmail, headers );
+					emailService.send(fromEmail, toEmail, rt.getRenderedSubject(), body, toEmail, fromEmail, additionalHeaders );
 				}
 				else{
 					emailService.sendToUsers(toAddress, headers, body);


### PR DESCRIPTION
Was using 'headers' in place of additionalheaders which caused method send
to fail.Headers are used differently in 'sendToUsers' therefore added
correct additionalHeaders in the 'send' method.
