### PR TITLE
WL-4242 Corrected the format of Account validation email.

### DIFF
--- a/impl/logic/src/java/org/sakaiproject/emailtemplateservice/service/impl/EmailTemplateServiceImpl.java
+++ b/impl/logic/src/java/org/sakaiproject/emailtemplateservice/service/impl/EmailTemplateServiceImpl.java
@@ -435,7 +435,7 @@ public void sendRenderedMessages(String key, List<String> userReferences,
 					List<String> additionalHeaders = new ArrayList<String>();
 					additionalHeaders.add("Content-Type: text/html; charset=UTF-8");
 					//sending email to new email address for user who has updated the email
-					emailService.send(fromEmail, toEmail, rt.getRenderedSubject(), body, toEmail, fromEmail, additionalHeaders );
+					emailService.send(fromEmail, toEmail, rt.getRenderedSubject(), rt.getRenderedHtmlMessage(), toEmail, fromEmail, additionalHeaders );
 				}
 				else{
 					emailService.sendToUsers(toAddress, headers, body);


### PR DESCRIPTION
In 'sendRenderedMessages' method for user who has changed the email
address , message body is send in the form of normal html message instead
of adding headers into the message.
